### PR TITLE
Sitecore.FXM.Solr.DomainsSearch.DefaultIndexConfiguration.config.disabled should be enabled on CD

### DIFF
--- a/8.1.xml
+++ b/8.1.xml
@@ -1690,7 +1690,7 @@
 			<ConfigFileName>Sitecore.FXM.Solr.DomainsSearch.DefaultIndexConfiguration.config.disabled</ConfigFileName>
 			<ConfigType>disabled</ConfigType>
 			<SearchProviderUsed>Solr is used</SearchProviderUsed>
-			<ContentDelivery>Disable</ContentDelivery>
+			<ContentDelivery>Enable</ContentDelivery>
 			<ContentManagement>Enable</ContentManagement>
 			<Processing>Disable</Processing>
 			<CMProcessing>Enable</CMProcessing>


### PR DESCRIPTION
According to the latest excel file from Sitecore for version 81 upd 3, Sitecore.FXM.Solr.DomainsSearch.DefaultIndexConfiguration.config.disabled should be enable on CD when using solr

See
https://doc.sitecore.net//~/media/2ABDC8F1C30E46B0BACBD9ADF6020197.ashx?la=en